### PR TITLE
Fix image not found

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,8 +8,8 @@ menu:
 
 # Pictures shown on the sidebar
 # Use the absolute URL after generating
-# avatar: /assets/tree_small.png
-# sidebar_background: /assets/header.png
+# avatar: assets/tree_small.png
+# sidebar_background: assets/header.png
 
 rss: /atom.xml
 

--- a/layout/_partial/sidebar.ejs
+++ b/layout/_partial/sidebar.ejs
@@ -1,6 +1,6 @@
 <aside class='SideBar'>
-    <section class='avatar' style="background-image: url(<%= theme.sidebar_background %>)">
-        <div class='av-pic' style="background-image: url(<%= theme.avatar %>)">
+    <section class='avatar' style="background-image: url(<%= config.root %><%= theme.sidebar_background %>)">
+        <div class='av-pic' style="background-image: url(<%= config.root %><%= theme.avatar %>)">
         </div>
     </section>
     <section class='menu'>
@@ -20,7 +20,7 @@
         <% for (const m in theme.media) { %>
             <% if (theme.media[m]) { %>
                 <a href="<%- url_for(theme.media[m]) %>">
-                    <img src="/assets/<%= m %>.svg" />
+                    <img src="<%= config.root %>assets/<%= m %>.svg" />
                 </a>
             <% } %>
         <% } %>


### PR DESCRIPTION
If user's website is in a subdirectory will cause an image not found error.
Add `<%= config.root %>` to fix this problem.