### PR TITLE
调整页脚信息

### DIFF
--- a/layout/_partial/footer.ejs
+++ b/layout/_partial/footer.ejs
@@ -1,6 +1,12 @@
 <footer>
-    <div>© 2016 - <%= config.author %> <% if (config.license) { %> , <%= config.license %> <% } %></div>
+    <div>© <%= new Date().getFullYear() %> - <%= config.author %> <% if (config.license) { %> , <%= config.license %> <% } %></div>
     <div>
-    Powered by Hexo
+        <span>
+            Powered by <a href="https://hexo.io">Hexo</a>
+        </span>
+        ,
+        <span>
+            Theme - <a href="https://github.com/nameoverflow/hexo-theme-icalm">Icalm</a>
+        </span>
     </div>
 </footer>

--- a/source/css/_partial/layout.styl
+++ b/source/css/_partial/layout.styl
@@ -2,6 +2,7 @@ $link_color_d = rgb(104, 104, 104)
 $link_color_h = rgb(14, 14, 14)
 
 $text-color = rgb(74, 74, 74)
+$text-muted-color = rgb(204, 204, 204)
 
 fill-full(l, r)
     position: absolute
@@ -68,10 +69,16 @@ blockquote
         > footer
             width: 100%
             text-align: center
-            color: #ccc
+            color: $text-muted-color
             font-size: 14px
             line-height: 20px
             padding: 5rem 0 2rem
+            a
+                color: $text-muted-color
+                border-color: $text-muted-color
+                &:hover
+                    color: darken($text-muted-color, 50%)
+                    border-color: darken($text-muted-color, 50%)
 
 .Index, .TagArticle
     padding: 7em 0 0 0
@@ -203,4 +210,3 @@ blockquote
     100%
         transform: translate3d(100px, 0, 0)
         opacity: 0
-


### PR DESCRIPTION
### 修改描述

1. 增加 `hexo`、 `icalm` 相关链接

2. 调整 `版权所有` 年份，随浏览器更新

### 修改后截图

![没有协议时的页脚](https://user-images.githubusercontent.com/19590194/40874485-6d726dd0-665f-11e8-9b4c-7165179f8a2f.png)

![有协议时的页脚](https://user-images.githubusercontent.com/19590194/40874490-7d345080-665f-11e8-8b8b-ddf56d18ee79.png)

